### PR TITLE
feat: add lint-strategy input for squash-merge workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ jobs:
           fail-on-warnings: 'false' # Optional: Set to 'true' to fail on warnings
           fail-on-errors: 'true' # Optional: Set to 'false' to pass with errors as warnings
           help-url: 'https://your-project.com/commit-guidelines' # Optional: Your URL for commit guidelines
-          config-file: '.commitlintrc.js' # Optional: Path to your config file
           working-directory: '.' # Optional: Default is '.'
-          lint-strategy: 'commits' # Optional: 'commits' (default) | 'pr-title' | 'both'
+          lint-strategy: 'commits' # Optional: 'commits' (default) | 'pr-title' | 'both'. NOTE: 'pr-title' and 'both' require 'edited' in the pull_request trigger types — see "Squash-merge workflows" below.
 ```
 
 This workflow is configured to trigger commit linting on `pull_request` events and pushes to branches like `main` (or `develop`). It automatically validates all relevant commit messages against your defined standards, providing immediate feedback. This ensures your project's commit history remains clean and consistent from the moment changes are introduced.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,42 @@ jobs:
           help-url: 'https://your-project.com/commit-guidelines' # Optional: Your URL for commit guidelines
           config-file: '.commitlintrc.js' # Optional: Path to your config file
           working-directory: '.' # Optional: Default is '.'
+          lint-strategy: 'commits' # Optional: 'commits' (default) | 'pr-title' | 'both'
 ```
 
 This workflow is configured to trigger commit linting on `pull_request` events and pushes to branches like `main` (or `develop`). It automatically validates all relevant commit messages against your defined standards, providing immediate feedback. This ensures your project's commit history remains clean and consistent from the moment changes are introduced.
+
+### Squash-merge workflows
+
+If your repository **only** uses squash-merge, the individual commits on a feature branch are thrown away at merge time; only a single squash commit lands in `main`, and its message defaults to the **PR title**. Linting the ephemeral per-commit messages in that case is busywork — the thing that actually ends up in git history is the PR title, and that's what you want to enforce conventional-commit rules on.
+
+Set `lint-strategy: pr-title` to lint the PR title instead of the commits. The action reads the title directly from the webhook payload, so no extra GitHub API calls are made.
+
+```yaml
+name: Commit Lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: mridang/action-commit-lint@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lint-strategy: pr-title
+```
+
+If you want defence-in-depth — enforce the rules on both individual commits _and_ the PR title that will become the squash commit — use `lint-strategy: both` instead.
+
+> **Safe with mixed triggers:** On `push` or `merge_group` events the payload has no PR title to read, and `lint-strategy: pr-title` will **skip linting and emit a workflow notice** rather than failing. This means you can safely combine `pull_request` and `push: branches: [main]` triggers in the same workflow without the post-merge `push` run failing.
 
 ## Inputs
 
@@ -65,6 +98,10 @@ This workflow is configured to trigger commit linting on `pull_request` events a
 - **`fail-on-warnings`** (optional, default: `'false'`): If `'true'`, the action will fail if any linting **warnings** are found. By default, warnings won't cause the action to fail.
 - **`fail-on-errors`** (optional, default: `'true'`): If `'false'`, the action will pass with a warning message even if linting **errors** are found. By default, errors will cause the action to fail.
 - **`help-url`** (optional): A URL that'll show up in linting error messages, guiding users to your project's specific commit message guidelines.
+- **`lint-strategy`** (optional, default: `'commits'`): Which items to lint.
+  - `'commits'` — lint each commit in the event. This is the default and preserves existing behaviour.
+  - `'pr-title'` — lint only the pull request title. Useful for **squash-merge** workflows where individual commit messages are discarded at merge time and the PR title becomes the squash commit message. On `push` and `merge_group` events the payload has no PR title to read, so the action emits a workflow notice and skips linting (rather than failing) — this makes the strategy safe to combine with `push` triggers on your default branch.
+  - `'both'` — lint the PR title _and_ every commit. On events without a PR title in the payload (e.g. `push`), this degrades gracefully and behaves exactly like `'commits'`. The PR title is not counted towards `commit-depth`; depth limits commits only.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If your repository **only** uses squash-merge, the individual commits on a featu
 
 Set `lint-strategy: pr-title` to lint the PR title instead of the commits. The action reads the title directly from the webhook payload, so no extra GitHub API calls are made.
 
-> **Important — include `edited` in `types`:** GitHub's default `pull_request` activity types are `[opened, synchronize, reopened]` and **do not include `edited`**. If you forget to add `edited`, a contributor who opens a PR with a bad title and then **fixes the title in the GitHub UI will not re-trigger the workflow**, leaving them stuck unless they push a new commit. Always opt in to `edited` when using `lint-strategy: pr-title`.
+> **Important — include `edited` in `types`:** GitHub's default `pull_request` activity types are `[opened, synchronize, reopened]` and **do not include `edited`**. If you forget to add `edited`, a contributor who opens a PR with a bad title and then **fixes the title in the GitHub UI will not re-trigger the workflow**, leaving them stuck unless they push a new commit. Always opt in to `edited` when using `lint-strategy: pr-title` _or_ `lint-strategy: both`, since both strategies enforce rules on the PR title.
 
 ```yaml
 name: Commit Lint
@@ -89,7 +89,7 @@ jobs:
           lint-strategy: pr-title
 ```
 
-If you want defence-in-depth — enforce the rules on both individual commits _and_ the PR title that will become the squash commit — use `lint-strategy: both` instead.
+If you want defence-in-depth — enforce the rules on both individual commits _and_ the PR title that will become the squash commit — use `lint-strategy: both` instead. The same `edited` requirement applies: include it in your trigger's `types` so the action re-runs after a PR title is fixed.
 
 > **Safe with mixed triggers:** On `push` or `merge_group` events the payload has no PR title to read, and `lint-strategy: pr-title` will **skip linting and emit a workflow notice** rather than failing. This means you can safely combine `pull_request` and `push: branches: [main]` triggers in the same workflow without the post-merge `push` run failing.
 
@@ -104,7 +104,7 @@ If you want defence-in-depth — enforce the rules on both individual commits _a
 - **`lint-strategy`** (optional, default: `'commits'`): Which items to lint.
   - `'commits'` — lint each commit in the event. This is the default and preserves existing behaviour.
   - `'pr-title'` — lint only the pull request title. Useful for **squash-merge** workflows where individual commit messages are discarded at merge time and the PR title becomes the squash commit message. On events without a pull request in the payload (e.g. `push`, `merge_group`) the action emits a workflow notice and skips linting (rather than failing) — this makes the strategy safe to combine with `push` triggers on your default branch. **Important:** when using this strategy on `pull_request`, include `edited` in your trigger's `types` (e.g. `types: [opened, synchronize, reopened, edited]`) so the action re-runs when a contributor fixes a bad PR title in the GitHub UI; otherwise the workflow won't re-fire after a title edit.
-  - `'both'` — lint the PR title _and_ every commit. On events without a PR title in the payload (e.g. `push`), this degrades gracefully and behaves exactly like `'commits'`. The PR title is not counted towards `commit-depth`; depth limits commits only.
+  - `'both'` — lint the PR title _and_ every commit. On events without a PR title in the payload (e.g. `push`), this degrades gracefully and behaves exactly like `'commits'`. The PR title is not counted towards `commit-depth`; depth limits commits only. **Important:** as with `'pr-title'`, include `edited` in your `pull_request` trigger's `types` so the action re-runs after a contributor fixes a bad PR title in the GitHub UI.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ If your repository **only** uses squash-merge, the individual commits on a featu
 
 Set `lint-strategy: pr-title` to lint the PR title instead of the commits. The action reads the title directly from the webhook payload, so no extra GitHub API calls are made.
 
+> **Important — include `edited` in `types`:** GitHub's default `pull_request` activity types are `[opened, synchronize, reopened]` and **do not include `edited`**. If you forget to add `edited`, a contributor who opens a PR with a bad title and then **fixes the title in the GitHub UI will not re-trigger the workflow**, leaving them stuck unless they push a new commit. Always opt in to `edited` when using `lint-strategy: pr-title`.
+
 ```yaml
 name: Commit Lint
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -100,7 +103,7 @@ If you want defence-in-depth — enforce the rules on both individual commits _a
 - **`help-url`** (optional): A URL that'll show up in linting error messages, guiding users to your project's specific commit message guidelines.
 - **`lint-strategy`** (optional, default: `'commits'`): Which items to lint.
   - `'commits'` — lint each commit in the event. This is the default and preserves existing behaviour.
-  - `'pr-title'` — lint only the pull request title. Useful for **squash-merge** workflows where individual commit messages are discarded at merge time and the PR title becomes the squash commit message. On `push` and `merge_group` events the payload has no PR title to read, so the action emits a workflow notice and skips linting (rather than failing) — this makes the strategy safe to combine with `push` triggers on your default branch.
+  - `'pr-title'` — lint only the pull request title. Useful for **squash-merge** workflows where individual commit messages are discarded at merge time and the PR title becomes the squash commit message. On events without a pull request in the payload (e.g. `push`, `merge_group`) the action emits a workflow notice and skips linting (rather than failing) — this makes the strategy safe to combine with `push` triggers on your default branch. **Important:** when using this strategy on `pull_request`, include `edited` in your trigger's `types` (e.g. `types: [opened, synchronize, reopened, edited]`) so the action re-runs when a contributor fixes a bad PR title in the GitHub UI; otherwise the workflow won't re-fire after a title edit.
   - `'both'` — lint the PR title _and_ every commit. On events without a PR title in the payload (e.g. `push`), this degrades gracefully and behaves exactly like `'commits'`. The PR title is not counted towards `commit-depth`; depth limits commits only.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,13 @@ inputs:
       event. 'pr-title' lints only the pull request title, which is the
       message that lands in git history for squash-merge workflows.
       'both' lints the PR title and every commit. When set to 'pr-title'
-      on events without a pull request context (push, merge_group), no
-      items will be linted and the action will fail with 'No commits
-      found to lint'.
+      on events without a pull request in the payload (e.g. push,
+      merge_group), the action emits a workflow notice and exits
+      successfully instead of failing, making it safe to combine with
+      push triggers on your default branch. When using 'pr-title' on
+      pull_request triggers, include 'edited' in the trigger's 'types'
+      list so the action re-runs after a contributor fixes a bad title
+      in the GitHub UI.
     required: false
     default: 'commits'
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Commit Linter
 
 description: |
-  GitHub Action that auto-installs commitlint configs/plugins, lints recent commits and posts a colored summary report.
+  GitHub Action that auto-installs commitlint configs/plugins, lints commits or the pull request title (configurable for squash-merge workflows) and posts a colored summary report.
 
 author: mridang
 branding:
@@ -48,6 +48,14 @@ inputs:
     description: >
       A URL to display in linting error messages, pointing users to your
       commit message guidelines.
+    required: false
+
+  working-directory:
+    description: >
+      The directory the action treats as the project root for resolving
+      the commitlint configuration and any installed plugins. Defaults
+      to the current process working directory (the repository root in
+      a typical workflow).
     required: false
 
   lint-strategy:

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,18 @@ inputs:
       commit message guidelines.
     required: false
 
+  lint-strategy:
+    description: >
+      Which items to lint. 'commits' (default) lints each commit in the
+      event. 'pr-title' lints only the pull request title, which is the
+      message that lands in git history for squash-merge workflows.
+      'both' lints the PR title and every commit. When set to 'pr-title'
+      on events without a pull request context (push, merge_group), no
+      items will be linted and the action will fail with 'No commits
+      found to lint'.
+    required: false
+    default: 'commits'
+
 runs:
   using: node24
   main: dist/main.cjs

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -284111,6 +284111,146 @@ class DefaultFormatter {
     }
 }
 
+/**
+ * Lints every commit returned by the event's fetcher. This is the default
+ * behaviour and preserves backwards compatibility with workflows that do
+ * not specify a `lint-strategy` input.
+ */
+class CommitsStrategy {
+    /**
+     * Invokes the supplied fetcher callback and returns its result
+     * verbatim. Ignores the strategy context entirely; the event-specific
+     * fetcher is the sole source of items.
+     *
+     * @param _ctx Unused; present to satisfy the {@link LintTargetStrategy}
+     * contract.
+     * @param fetchCommits Callback that produces the commits for the
+     * current event (already depth-limited by `run()`).
+     * @returns The commits returned by `fetchCommits`, unchanged.
+     */
+    async resolve(_ctx, fetchCommits) {
+        return fetchCommits();
+    }
+}
+
+/**
+ * Lints only the pull request title read from the webhook payload. Does
+ * not invoke the commit fetcher, so no GitHub API call is made on behalf
+ * of this strategy. On events without a `pull_request` payload (push,
+ * merge_group) it returns an empty list; the caller then triggers the
+ * action's standard "No commits found to lint" failure path.
+ *
+ * The synthetic hash is shaped `pr-{number}-title` so it renders
+ * distinctly from a real SHA in the job summary.
+ *
+ * Reads `payload.pull_request` directly from `WebhookPayload`. The
+ * upstream type guarantees `number: number` when `pull_request` is
+ * present, but `title` arrives via the `[key: string]: any` index
+ * signature, so it is captured as `unknown` and runtime-checked before
+ * use to keep `any` from leaking into the rest of the code.
+ */
+class PrTitleStrategy {
+    /**
+     * Builds a single-element list containing the pull request title as a
+     * synthetic {@link CommitToLint}, or an empty list when the payload
+     * has no usable PR title. Never invokes `fetchCommits`, so the
+     * underlying GitHub API call is skipped entirely when this strategy
+     * is selected.
+     *
+     * @param ctx Read-only context whose `payload.pull_request` is
+     * inspected for `title`.
+     * @returns A frozen list with one frozen item on PR events with a
+     * non-empty title, otherwise a frozen empty list.
+     */
+    async resolve(ctx) {
+        const pr = ctx.payload.pull_request;
+        if (pr === undefined) {
+            return Object.freeze([]);
+        }
+        const title = pr.title;
+        if (typeof title !== 'string' || title.length === 0) {
+            return Object.freeze([]);
+        }
+        const item = Object.freeze({
+            message: title,
+            hash: `pr-${pr.number}-title`,
+        });
+        return Object.freeze([item]);
+    }
+}
+
+/**
+ * Lints the pull request title and every commit. Composes
+ * {@link PrTitleStrategy} and {@link CommitsStrategy} and concatenates
+ * their results with the title first.
+ *
+ * Gracefully degrades on events without a `pull_request` payload: the
+ * title half yields an empty list and the commits half returns whatever
+ * the fetcher provides, so this strategy is equivalent to `commits` on
+ * push and merge_group events.
+ *
+ * The PR title is never trimmed by `commit-depth`; depth is applied to
+ * the commits inside the `fetchCommits` callback passed from `run()`,
+ * and the title is prepended afterwards.
+ */
+class BothStrategy {
+    commits;
+    prTitle;
+    /**
+     * Constructs the composite strategy. Both sub-strategies have sensible
+     * defaults; the parameters exist primarily so unit tests can inject
+     * mocks and verify delegation.
+     *
+     * @param commits Strategy used to resolve the commit half of the
+     * result. Defaults to a fresh {@link CommitsStrategy}.
+     * @param prTitle Strategy used to resolve the title half of the
+     * result. Defaults to a fresh {@link PrTitleStrategy}.
+     */
+    constructor(commits = new CommitsStrategy(), prTitle = new PrTitleStrategy()) {
+        this.commits = commits;
+        this.prTitle = prTitle;
+    }
+    /**
+     * Resolves both halves in parallel and concatenates them, title first.
+     * The two sub-strategies are invoked with the same `fetchCommits`
+     * callback; in practice only the commit sub-strategy actually calls
+     * it, so the underlying fetch happens at most once per `resolve()`.
+     *
+     * @param ctx Read-only context forwarded to both sub-strategies.
+     * @param fetchCommits Callback that produces the commits for the
+     * current event (already depth-limited by `run()`).
+     * @returns A frozen list shaped `[title, ...commits]`. On non-PR
+     * events the title half yields nothing, so the result equals the
+     * commits the fetcher returned.
+     */
+    async resolve(ctx, fetchCommits) {
+        const [titleItems, commitItems] = await Promise.all([
+            this.prTitle.resolve(ctx, fetchCommits),
+            this.commits.resolve(ctx, fetchCommits),
+        ]);
+        return Object.freeze([...titleItems, ...commitItems]);
+    }
+}
+
+/**
+ * Constructs a {@link LintTargetStrategy} for the given name. The caller
+ * is responsible for validating the input value before invoking this
+ * factory; all three valid names are handled exhaustively.
+ *
+ * @param name The parsed `lint-strategy` input value.
+ * @returns A ready-to-use strategy instance.
+ */
+function getLintStrategy$1(name) {
+    switch (name) {
+        case 'commits':
+            return new CommitsStrategy();
+        case 'pr-title':
+            return new PrTitleStrategy();
+        case 'both':
+            return new BothStrategy();
+    }
+}
+
 /* eslint-disable */
 /**
  * Retrieves the 'commit-depth' input.
@@ -284202,6 +284342,30 @@ function getHelpURL() {
     return coreExports.getInput('help-url');
 }
 /**
+ * Retrieves the 'lint-strategy' input and narrows it to a
+ * {@link LintStrategyName}. Empty input defaults to `'commits'` to
+ * preserve backwards compatibility.
+ *
+ * @returns The parsed strategy name.
+ * @throws {Error} If the input is set to a value other than
+ * `'commits'`, `'pr-title'`, `'both'`, or the empty string.
+ */
+function getLintStrategy() {
+    const raw = coreExports.getInput('lint-strategy').trim().toLowerCase();
+    if (raw === '' || raw === 'commits') {
+        return 'commits';
+    }
+    else if (raw === 'pr-title') {
+        return 'pr-title';
+    }
+    else if (raw === 'both') {
+        return 'both';
+    }
+    else {
+        throw new Error(`Invalid value for "lint-strategy". Expected 'commits', 'pr-title', or 'both', but received '${raw}'.`);
+    }
+}
+/**
  * Retrieves the working directory from the action's 'working-directory' input.
  *
  * @returns The specified working directory or the current process's
@@ -284278,10 +284442,20 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
             coreExports.info(`Fetching commits for event: ${ghCtx.eventName}`);
             const commitFetcher = commitFetcherFactory(ghCtx.eventName);
             if (commitFetcher) {
-                const eventCommits = await commitFetcher.fetchCommits(githubToken, ghCtx.repo.owner, ghCtx.repo.repo, ghCtx.payload);
-                const commitsToLint = commitDepth && eventCommits.length > commitDepth
-                    ? eventCommits.slice(0, commitDepth)
-                    : eventCommits;
+                const lintStrategyName = getLintStrategy();
+                if (lintStrategyName === 'pr-title' &&
+                    ghCtx.payload.pull_request === undefined) {
+                    coreExports.notice(`lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on push and merge_group events triggered by squash-merges.`);
+                    return;
+                }
+                const strategy = getLintStrategy$1(lintStrategyName);
+                const fetchAndLimit = async () => {
+                    const all = await commitFetcher.fetchCommits(githubToken, ghCtx.repo.owner, ghCtx.repo.repo, ghCtx.payload);
+                    return commitDepth && all.length > commitDepth
+                        ? all.slice(0, commitDepth)
+                        : all;
+                };
+                const commitsToLint = await strategy.resolve({ eventName: ghCtx.eventName, payload: ghCtx.payload }, fetchAndLimit);
                 if (commitsToLint.length > 0) {
                     coreExports.startGroup('Running commit-lint');
                     const failOnWarns = getFailOnWarnings();

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -257497,15 +257497,33 @@ class Results {
      */
     helpUrl;
     /**
-     * The total number of errors across all linted commits. This value is
-     * pre-calculated in the constructor for O(1) access.
+     * The total number of errors across all linted commits. A single commit
+     * with three errors contributes three to this count. Pre-calculated in
+     * the constructor for O(1) access.
      */
     errorCount;
     /**
-     * The total number of warnings across all linted commits. This value is
-     * pre-calculated in the constructor for O(1) access.
+     * The total number of warnings across all linted commits. A single
+     * commit with three warnings contributes three to this count.
+     * Pre-calculated in the constructor for O(1) access.
      */
     warningCount;
+    /**
+     * The number of distinct commits that contain at least one error. A
+     * commit with three errors contributes one to this count. Use this when
+     * reporting "N commit messages failed", as opposed to {@link errorCount}
+     * which counts individual errors. Pre-calculated in the constructor for
+     * O(1) access.
+     */
+    errorCommitsCount;
+    /**
+     * The number of distinct commits that contain at least one warning. A
+     * commit with three warnings contributes one to this count. Use this
+     * when reporting "N commit messages have warnings", as opposed to
+     * {@link warningCount} which counts individual warnings. Pre-calculated
+     * in the constructor for O(1) access.
+     */
+    warningCommitsCount;
     /**
      * Constructs a new Results instance. It eagerly processes the provided
      * linting results to generate and store aggregate counts for errors and
@@ -257517,12 +257535,21 @@ class Results {
     constructor(items, helpUrl) {
         this.items = items;
         this.helpUrl = helpUrl;
-        const { errorCount, warningCount } = items.reduce((counts, item) => ({
+        const { errorCount, warningCount, errorCommitsCount, warningCommitsCount } = items.reduce((counts, item) => ({
             errorCount: counts.errorCount + item.errors.length,
             warningCount: counts.warningCount + item.warnings.length,
-        }), { errorCount: 0, warningCount: 0 });
+            errorCommitsCount: counts.errorCommitsCount + (item.errors.length > 0 ? 1 : 0),
+            warningCommitsCount: counts.warningCommitsCount + (item.warnings.length > 0 ? 1 : 0),
+        }), {
+            errorCount: 0,
+            warningCount: 0,
+            errorCommitsCount: 0,
+            warningCommitsCount: 0,
+        });
         this.errorCount = errorCount;
         this.warningCount = warningCount;
+        this.errorCommitsCount = errorCommitsCount;
+        this.warningCommitsCount = warningCommitsCount;
     }
     /**
      * Gets the total number of commits that were analyzed by the linter.
@@ -284052,7 +284079,7 @@ class DefaultFormatter {
         await summary.write();
     }
     formatSummary(results, summary) {
-        const errorCommitsCount = results.items.filter((item) => item.errors.length > 0).length;
+        const errorCommitsCount = results.errorCommitsCount;
         const warningOnlyCommitsCount = results.items.filter((item) => item.errors.length === 0 && item.warnings.length > 0).length;
         const cleanCommitsCount = results.checkedCount - errorCommitsCount - warningOnlyCommitsCount;
         const headlineNoun = results.checkedCount === 1 ? 'message was' : 'messages were';
@@ -284480,7 +284507,7 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                     await result1.format(new DefaultFormatter());
                     if (result1.hasErrors) {
                         if (failOnErrs) {
-                            setFailed(`Found ${result1.errorCount} commit message${result1.errorCount === 1 ? '' : 's'} with errors`);
+                            setFailed(`Found ${result1.errorCommitsCount} commit message${result1.errorCommitsCount === 1 ? '' : 's'} with errors`);
                         }
                         else {
                             coreExports.warning(`Commit messages have errors, but 'fail-on-errors' is false.`);
@@ -284488,7 +284515,7 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                     }
                     else if (result1.hasOnlyWarnings) {
                         if (failOnWarns) {
-                            setFailed(`Found ${result1.warningCount} commit message${result1.warningCount === 1 ? '' : 's'} with warnings`);
+                            setFailed(`Found ${result1.warningCommitsCount} commit message${result1.warningCommitsCount === 1 ? '' : 's'} with warnings`);
                         }
                         else {
                             coreExports.warning(`Commit messages have warnings, but 'fail-on-warnings' is false.`);

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -284164,7 +284164,7 @@ class PrTitleStrategy {
      */
     async resolve(ctx) {
         const pr = ctx.payload.pull_request;
-        if (pr === undefined) {
+        if (pr === undefined || pr === null) {
             return Object.freeze([]);
         }
         const title = pr.title;
@@ -284444,8 +284444,9 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
             if (commitFetcher) {
                 const lintStrategyName = getLintStrategy();
                 if (lintStrategyName === 'pr-title' &&
-                    ghCtx.payload.pull_request === undefined) {
-                    coreExports.notice(`lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on push and merge_group events triggered by squash-merges.`);
+                    (ghCtx.payload.pull_request === undefined ||
+                        ghCtx.payload.pull_request === null)) {
+                    coreExports.notice(`lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context, such as a 'push' event fired after a squash-merge lands on the default branch.`);
                     return;
                 }
                 const strategy = getLintStrategy$1(lintStrategyName);

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -284055,15 +284055,19 @@ class DefaultFormatter {
         const errorCommitsCount = results.items.filter((item) => item.errors.length > 0).length;
         const warningOnlyCommitsCount = results.items.filter((item) => item.errors.length === 0 && item.warnings.length > 0).length;
         const cleanCommitsCount = results.checkedCount - errorCommitsCount - warningOnlyCommitsCount;
-        const itemNoun = results.checkedCount === 1 ? 'message was' : 'messages were';
+        const headlineNoun = results.checkedCount === 1 ? 'message was' : 'messages were';
+        const cleanNoun = cleanCommitsCount === 1 ? 'message' : 'messages';
+        const cleanVerb = cleanCommitsCount === 1 ? 'follows' : 'follow';
+        const warnNoun = warningOnlyCommitsCount === 1 ? 'message has' : 'messages have';
+        const errorNoun = errorCommitsCount === 1 ? 'message' : 'messages';
         const summaryLines = [
-            `The following ${results.checkedCount} ${itemNoun} analyzed.`,
+            `The following ${results.checkedCount} ${headlineNoun} analyzed.`,
             cleanCommitsCount > 0 &&
-                `${cleanCommitsCount} passed commitlint checks and follow the conventional commit format.`,
+                `${cleanCommitsCount} ${cleanNoun} passed commitlint checks and ${cleanVerb} the conventional commit format.`,
             warningOnlyCommitsCount > 0 &&
-                `${warningOnlyCommitsCount} ${warningOnlyCommitsCount > 1 ? 'have' : 'has'} warnings that should be reviewed.`,
+                `${warningOnlyCommitsCount} ${warnNoun} warnings that should be reviewed.`,
             errorCommitsCount > 0 &&
-                `${errorCommitsCount} failed and must be corrected.`,
+                `${errorCommitsCount} ${errorNoun} failed and must be corrected.`,
         ]
             .filter((line) => typeof line === 'string')
             .join(' ');
@@ -284487,11 +284491,11 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                             setFailed(`Found ${result1.warningCount} commit message${result1.warningCount === 1 ? '' : 's'} with warnings`);
                         }
                         else {
-                            coreExports.warning(`Commit messages have warning, but 'fail-on-warnings' is false.`);
+                            coreExports.warning(`Commit messages have warnings, but 'fail-on-warnings' is false.`);
                         }
                     }
                     else {
-                        coreExports.info(`All ${result1.checkedCount} commit messages are okay.`);
+                        coreExports.info(`All ${result1.checkedCount} commit message${result1.checkedCount === 1 ? ' is' : 's are'} okay.`);
                     }
                     coreExports.endGroup();
                 }

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -284456,7 +284456,7 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                 if (lintStrategyName === 'pr-title' &&
                     (ghCtx.payload.pull_request === undefined ||
                         ghCtx.payload.pull_request === null)) {
-                    coreExports.notice(`lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context, such as a 'push' event fired after a squash-merge lands on the default branch.`);
+                    coreExports.notice(`lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context (e.g. 'push' fired after a squash-merge lands on the default branch, or 'merge_group' from the merge queue).`);
                     return;
                 }
                 const strategy = getLintStrategy$1(lintStrategyName);

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -284055,14 +284055,15 @@ class DefaultFormatter {
         const errorCommitsCount = results.items.filter((item) => item.errors.length > 0).length;
         const warningOnlyCommitsCount = results.items.filter((item) => item.errors.length === 0 && item.warnings.length > 0).length;
         const cleanCommitsCount = results.checkedCount - errorCommitsCount - warningOnlyCommitsCount;
+        const itemNoun = results.checkedCount === 1 ? 'message was' : 'messages were';
         const summaryLines = [
-            `The following ${results.checkedCount} commits were analyzed as part of this push.`,
+            `The following ${results.checkedCount} ${itemNoun} analyzed.`,
             cleanCommitsCount > 0 &&
-                `${cleanCommitsCount} commits passed commitlint checks and follow the conventional commit format.`,
+                `${cleanCommitsCount} passed commitlint checks and follow the conventional commit format.`,
             warningOnlyCommitsCount > 0 &&
-                `${warningOnlyCommitsCount} commit${warningOnlyCommitsCount > 1 ? 's have' : ' has'} warnings that should be reviewed.`,
+                `${warningOnlyCommitsCount} ${warningOnlyCommitsCount > 1 ? 'have' : 'has'} warnings that should be reviewed.`,
             errorCommitsCount > 0 &&
-                `${errorCommitsCount} commit${errorCommitsCount > 1 ? 's' : ''} failed and must be corrected.`,
+                `${errorCommitsCount} failed and must be corrected.`,
         ]
             .filter((line) => typeof line === 'string')
             .join(' ');
@@ -284074,7 +284075,7 @@ class DefaultFormatter {
         }
         const header = [
             { data: 'Status', header: true },
-            { data: 'SHA', header: true },
+            { data: 'ID', header: true },
             { data: 'Message', header: true },
             { data: 'Notes', header: true },
         ];
@@ -284235,10 +284236,15 @@ class BothStrategy {
 /**
  * Constructs a {@link LintTargetStrategy} for the given name. The caller
  * is responsible for validating the input value before invoking this
- * factory; all three valid names are handled exhaustively.
+ * factory; all three valid names are handled exhaustively. The default
+ * branch is unreachable under TypeScript's type checker but throws at
+ * runtime as a defensive guard against unchecked casts and future
+ * additions to {@link LintStrategyName} that forget to update this
+ * switch.
  *
  * @param name The parsed `lint-strategy` input value.
  * @returns A ready-to-use strategy instance.
+ * @throws {Error} If `name` is not a recognised strategy at runtime.
  */
 function getLintStrategy$1(name) {
     switch (name) {
@@ -284248,6 +284254,10 @@ function getLintStrategy$1(name) {
             return new PrTitleStrategy();
         case 'both':
             return new BothStrategy();
+        default: {
+            const exhaustive = name;
+            throw new Error(`Unknown lint strategy: ${exhaustive}`);
+        }
     }
 }
 
@@ -284466,7 +284476,7 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                     await result1.format(new DefaultFormatter());
                     if (result1.hasErrors) {
                         if (failOnErrs) {
-                            setFailed(`Found ${result1.errorCount} commit messages with errors`);
+                            setFailed(`Found ${result1.errorCount} commit message${result1.errorCount === 1 ? '' : 's'} with errors`);
                         }
                         else {
                             coreExports.warning(`Commit messages have errors, but 'fail-on-errors' is false.`);
@@ -284474,7 +284484,7 @@ async function run(ghCtx = new contextExports.Context(), commitFetcherFactory = 
                     }
                     else if (result1.hasOnlyWarnings) {
                         if (failOnWarns) {
-                            setFailed(`Found ${result1.warningCount} commit messages with warnings`);
+                            setFailed(`Found ${result1.warningCount} commit message${result1.warningCount === 1 ? '' : 's'} with warnings`);
                         }
                         else {
                             coreExports.warning(`Commit messages have warning, but 'fail-on-warnings' is false.`);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "license": "Apache-2.0",
-  "description": "GitHub Action that auto-installs commitlint configs/plugins, lints recent commits and posts a colored summary report.",
+  "description": "GitHub Action that auto-installs commitlint configs/plugins, lints commits or the pull request title (configurable for squash-merge workflows) and posts a colored summary report.",
   "private": false,
   "engines": {
     "node": ">=22.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ export async function run(
           if (result1.hasErrors) {
             if (failOnErrs) {
               setFailed(
-                `Found ${result1.errorCount} commit message${result1.errorCount === 1 ? '' : 's'} with errors`,
+                `Found ${result1.errorCommitsCount} commit message${result1.errorCommitsCount === 1 ? '' : 's'} with errors`,
               );
             } else {
               warning(
@@ -290,7 +290,7 @@ export async function run(
           } else if (result1.hasOnlyWarnings) {
             if (failOnWarns) {
               setFailed(
-                `Found ${result1.warningCount} commit message${result1.warningCount === 1 ? '' : 's'} with warnings`,
+                `Found ${result1.warningCommitsCount} commit message${result1.warningCommitsCount === 1 ? '' : 's'} with warnings`,
               );
             } else {
               warning(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   endGroup,
   getInput,
   info,
+  notice,
   setFailed as actionFailed,
   startGroup,
   warning,
@@ -17,6 +18,11 @@ import { Context } from '@actions/github/lib/context.js';
 import getCommitFetcher from './fetchers/index.js';
 import DefaultFormatter from './linter/formatter.js';
 import path from 'node:path';
+import type { CommitToLint } from './types.js';
+import {
+  getLintStrategy as makeLintStrategy,
+  type LintStrategyName,
+} from './strategies/index.js';
 
 /**
  * Retrieves the 'commit-depth' input.
@@ -112,6 +118,30 @@ function getHelpURL(): string {
 }
 
 /**
+ * Retrieves the 'lint-strategy' input and narrows it to a
+ * {@link LintStrategyName}. Empty input defaults to `'commits'` to
+ * preserve backwards compatibility.
+ *
+ * @returns The parsed strategy name.
+ * @throws {Error} If the input is set to a value other than
+ * `'commits'`, `'pr-title'`, `'both'`, or the empty string.
+ */
+function getLintStrategy(): LintStrategyName {
+  const raw = getInput('lint-strategy').trim().toLowerCase();
+  if (raw === '' || raw === 'commits') {
+    return 'commits';
+  } else if (raw === 'pr-title') {
+    return 'pr-title';
+  } else if (raw === 'both') {
+    return 'both';
+  } else {
+    throw new Error(
+      `Invalid value for "lint-strategy". Expected 'commits', 'pr-title', or 'both', but received '${raw}'.`,
+    );
+  }
+}
+
+/**
  * Retrieves the working directory from the action's 'working-directory' input.
  *
  * @returns The specified working directory or the current process's
@@ -199,16 +229,38 @@ export async function run(
       info(`Fetching commits for event: ${ghCtx.eventName}`);
       const commitFetcher = commitFetcherFactory(ghCtx.eventName);
       if (commitFetcher) {
-        const eventCommits = await commitFetcher.fetchCommits(
-          githubToken,
-          ghCtx.repo.owner,
-          ghCtx.repo.repo,
-          ghCtx.payload,
+        const lintStrategyName = getLintStrategy();
+
+        if (
+          lintStrategyName === 'pr-title' &&
+          ghCtx.payload.pull_request === undefined
+        ) {
+          notice(
+            `lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on push and merge_group events triggered by squash-merges.`,
+          );
+          return;
+        }
+
+        const strategy = makeLintStrategy(lintStrategyName);
+
+        const fetchAndLimit = async (): Promise<
+          ReadonlyArray<CommitToLint>
+        > => {
+          const all = await commitFetcher.fetchCommits(
+            githubToken,
+            ghCtx.repo.owner,
+            ghCtx.repo.repo,
+            ghCtx.payload,
+          );
+          return commitDepth && all.length > commitDepth
+            ? all.slice(0, commitDepth)
+            : all;
+        };
+
+        const commitsToLint = await strategy.resolve(
+          { eventName: ghCtx.eventName, payload: ghCtx.payload },
+          fetchAndLimit,
         );
-        const commitsToLint =
-          commitDepth && eventCommits.length > commitDepth
-            ? eventCommits.slice(0, commitDepth)
-            : eventCommits;
 
         if (commitsToLint.length > 0) {
           startGroup('Running commit-lint');

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ export async function run(
           if (result1.hasErrors) {
             if (failOnErrs) {
               setFailed(
-                `Found ${result1.errorCount} commit messages with errors`,
+                `Found ${result1.errorCount} commit message${result1.errorCount === 1 ? '' : 's'} with errors`,
               );
             } else {
               warning(
@@ -290,7 +290,7 @@ export async function run(
           } else if (result1.hasOnlyWarnings) {
             if (failOnWarns) {
               setFailed(
-                `Found ${result1.warningCount} commit messages with warnings`,
+                `Found ${result1.warningCount} commit message${result1.warningCount === 1 ? '' : 's'} with warnings`,
               );
             } else {
               warning(

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,10 +233,11 @@ export async function run(
 
         if (
           lintStrategyName === 'pr-title' &&
-          ghCtx.payload.pull_request === undefined
+          (ghCtx.payload.pull_request === undefined ||
+            ghCtx.payload.pull_request === null)
         ) {
           notice(
-            `lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on push and merge_group events triggered by squash-merges.`,
+            `lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context, such as a 'push' event fired after a squash-merge lands on the default branch.`,
           );
           return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,7 @@ export async function run(
             ghCtx.payload.pull_request === null)
         ) {
           notice(
-            `lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context, such as a 'push' event fired after a squash-merge lands on the default branch.`,
+            `lint-strategy=pr-title: event '${ghCtx.eventName}' has no pull request in its payload, skipping. This is expected on events without a pull request context (e.g. 'push' fired after a squash-merge lands on the default branch, or 'merge_group' from the merge queue).`,
           );
           return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,11 +294,13 @@ export async function run(
               );
             } else {
               warning(
-                `Commit messages have warning, but 'fail-on-warnings' is false.`,
+                `Commit messages have warnings, but 'fail-on-warnings' is false.`,
               );
             }
           } else {
-            info(`All ${result1.checkedCount} commit messages are okay.`);
+            info(
+              `All ${result1.checkedCount} commit message${result1.checkedCount === 1 ? ' is' : 's are'} okay.`,
+            );
           }
           endGroup();
         } else {

--- a/src/linter/formatter.ts
+++ b/src/linter/formatter.ts
@@ -28,14 +28,16 @@ export default class DefaultFormatter implements Formatter {
     const cleanCommitsCount =
       results.checkedCount - errorCommitsCount - warningOnlyCommitsCount;
 
+    const itemNoun =
+      results.checkedCount === 1 ? 'message was' : 'messages were';
     const summaryLines = [
-      `The following ${results.checkedCount} commits were analyzed as part of this push.`,
+      `The following ${results.checkedCount} ${itemNoun} analyzed.`,
       cleanCommitsCount > 0 &&
-        `${cleanCommitsCount} commits passed commitlint checks and follow the conventional commit format.`,
+        `${cleanCommitsCount} passed commitlint checks and follow the conventional commit format.`,
       warningOnlyCommitsCount > 0 &&
-        `${warningOnlyCommitsCount} commit${warningOnlyCommitsCount > 1 ? 's have' : ' has'} warnings that should be reviewed.`,
+        `${warningOnlyCommitsCount} ${warningOnlyCommitsCount > 1 ? 'have' : 'has'} warnings that should be reviewed.`,
       errorCommitsCount > 0 &&
-        `${errorCommitsCount} commit${errorCommitsCount > 1 ? 's' : ''} failed and must be corrected.`,
+        `${errorCommitsCount} failed and must be corrected.`,
     ]
       .filter((line): line is string => typeof line === 'string')
       .join(' ');
@@ -50,7 +52,7 @@ export default class DefaultFormatter implements Formatter {
 
     const header: SummaryTableRow = [
       { data: 'Status', header: true },
-      { data: 'SHA', header: true },
+      { data: 'ID', header: true },
       { data: 'Message', header: true },
       { data: 'Notes', header: true },
     ];

--- a/src/linter/formatter.ts
+++ b/src/linter/formatter.ts
@@ -19,9 +19,7 @@ export default class DefaultFormatter implements Formatter {
   }
 
   private formatSummary(results: Results, summary: Summary): void {
-    const errorCommitsCount = results.items.filter(
-      (item) => item.errors.length > 0,
-    ).length;
+    const errorCommitsCount = results.errorCommitsCount;
     const warningOnlyCommitsCount = results.items.filter(
       (item) => item.errors.length === 0 && item.warnings.length > 0,
     ).length;

--- a/src/linter/formatter.ts
+++ b/src/linter/formatter.ts
@@ -28,16 +28,21 @@ export default class DefaultFormatter implements Formatter {
     const cleanCommitsCount =
       results.checkedCount - errorCommitsCount - warningOnlyCommitsCount;
 
-    const itemNoun =
+    const headlineNoun =
       results.checkedCount === 1 ? 'message was' : 'messages were';
+    const cleanNoun = cleanCommitsCount === 1 ? 'message' : 'messages';
+    const cleanVerb = cleanCommitsCount === 1 ? 'follows' : 'follow';
+    const warnNoun =
+      warningOnlyCommitsCount === 1 ? 'message has' : 'messages have';
+    const errorNoun = errorCommitsCount === 1 ? 'message' : 'messages';
     const summaryLines = [
-      `The following ${results.checkedCount} ${itemNoun} analyzed.`,
+      `The following ${results.checkedCount} ${headlineNoun} analyzed.`,
       cleanCommitsCount > 0 &&
-        `${cleanCommitsCount} passed commitlint checks and follow the conventional commit format.`,
+        `${cleanCommitsCount} ${cleanNoun} passed commitlint checks and ${cleanVerb} the conventional commit format.`,
       warningOnlyCommitsCount > 0 &&
-        `${warningOnlyCommitsCount} ${warningOnlyCommitsCount > 1 ? 'have' : 'has'} warnings that should be reviewed.`,
+        `${warningOnlyCommitsCount} ${warnNoun} warnings that should be reviewed.`,
       errorCommitsCount > 0 &&
-        `${errorCommitsCount} failed and must be corrected.`,
+        `${errorCommitsCount} ${errorNoun} failed and must be corrected.`,
     ]
       .filter((line): line is string => typeof line === 'string')
       .join(' ');

--- a/src/linter/result.ts
+++ b/src/linter/result.ts
@@ -17,16 +17,36 @@ export class Results {
   public readonly helpUrl: string;
 
   /**
-   * The total number of errors across all linted commits. This value is
-   * pre-calculated in the constructor for O(1) access.
+   * The total number of errors across all linted commits. A single commit
+   * with three errors contributes three to this count. Pre-calculated in
+   * the constructor for O(1) access.
    */
   public readonly errorCount: number;
 
   /**
-   * The total number of warnings across all linted commits. This value is
-   * pre-calculated in the constructor for O(1) access.
+   * The total number of warnings across all linted commits. A single
+   * commit with three warnings contributes three to this count.
+   * Pre-calculated in the constructor for O(1) access.
    */
   public readonly warningCount: number;
+
+  /**
+   * The number of distinct commits that contain at least one error. A
+   * commit with three errors contributes one to this count. Use this when
+   * reporting "N commit messages failed", as opposed to {@link errorCount}
+   * which counts individual errors. Pre-calculated in the constructor for
+   * O(1) access.
+   */
+  public readonly errorCommitsCount: number;
+
+  /**
+   * The number of distinct commits that contain at least one warning. A
+   * commit with three warnings contributes one to this count. Use this
+   * when reporting "N commit messages have warnings", as opposed to
+   * {@link warningCount} which counts individual warnings. Pre-calculated
+   * in the constructor for O(1) access.
+   */
+  public readonly warningCommitsCount: number;
 
   /**
    * Constructs a new Results instance. It eagerly processes the provided
@@ -40,16 +60,28 @@ export class Results {
     this.items = items;
     this.helpUrl = helpUrl;
 
-    const { errorCount, warningCount } = items.reduce(
-      (counts, item) => ({
-        errorCount: counts.errorCount + item.errors.length,
-        warningCount: counts.warningCount + item.warnings.length,
-      }),
-      { errorCount: 0, warningCount: 0 },
-    );
+    const { errorCount, warningCount, errorCommitsCount, warningCommitsCount } =
+      items.reduce(
+        (counts, item) => ({
+          errorCount: counts.errorCount + item.errors.length,
+          warningCount: counts.warningCount + item.warnings.length,
+          errorCommitsCount:
+            counts.errorCommitsCount + (item.errors.length > 0 ? 1 : 0),
+          warningCommitsCount:
+            counts.warningCommitsCount + (item.warnings.length > 0 ? 1 : 0),
+        }),
+        {
+          errorCount: 0,
+          warningCount: 0,
+          errorCommitsCount: 0,
+          warningCommitsCount: 0,
+        },
+      );
 
     this.errorCount = errorCount;
     this.warningCount = warningCount;
+    this.errorCommitsCount = errorCommitsCount;
+    this.warningCommitsCount = warningCommitsCount;
   }
 
   /**

--- a/src/strategies/both.ts
+++ b/src/strategies/both.ts
@@ -1,0 +1,65 @@
+import type { CommitToLint } from '../types.js';
+import type { LintTargetStrategy, StrategyContext } from './index.js';
+import { CommitsStrategy } from './commits.js';
+import { PrTitleStrategy } from './pr-title.js';
+
+/**
+ * Lints the pull request title and every commit. Composes
+ * {@link PrTitleStrategy} and {@link CommitsStrategy} and concatenates
+ * their results with the title first.
+ *
+ * Gracefully degrades on events without a `pull_request` payload: the
+ * title half yields an empty list and the commits half returns whatever
+ * the fetcher provides, so this strategy is equivalent to `commits` on
+ * push and merge_group events.
+ *
+ * The PR title is never trimmed by `commit-depth`; depth is applied to
+ * the commits inside the `fetchCommits` callback passed from `run()`,
+ * and the title is prepended afterwards.
+ */
+export class BothStrategy implements LintTargetStrategy {
+  private readonly commits: LintTargetStrategy;
+  private readonly prTitle: LintTargetStrategy;
+
+  /**
+   * Constructs the composite strategy. Both sub-strategies have sensible
+   * defaults; the parameters exist primarily so unit tests can inject
+   * mocks and verify delegation.
+   *
+   * @param commits Strategy used to resolve the commit half of the
+   * result. Defaults to a fresh {@link CommitsStrategy}.
+   * @param prTitle Strategy used to resolve the title half of the
+   * result. Defaults to a fresh {@link PrTitleStrategy}.
+   */
+  constructor(
+    commits: LintTargetStrategy = new CommitsStrategy(),
+    prTitle: LintTargetStrategy = new PrTitleStrategy(),
+  ) {
+    this.commits = commits;
+    this.prTitle = prTitle;
+  }
+
+  /**
+   * Resolves both halves in parallel and concatenates them, title first.
+   * The two sub-strategies are invoked with the same `fetchCommits`
+   * callback; in practice only the commit sub-strategy actually calls
+   * it, so the underlying fetch happens at most once per `resolve()`.
+   *
+   * @param ctx Read-only context forwarded to both sub-strategies.
+   * @param fetchCommits Callback that produces the commits for the
+   * current event (already depth-limited by `run()`).
+   * @returns A frozen list shaped `[title, ...commits]`. On non-PR
+   * events the title half yields nothing, so the result equals the
+   * commits the fetcher returned.
+   */
+  public async resolve(
+    ctx: StrategyContext,
+    fetchCommits: () => Promise<ReadonlyArray<CommitToLint>>,
+  ): Promise<ReadonlyArray<CommitToLint>> {
+    const [titleItems, commitItems] = await Promise.all([
+      this.prTitle.resolve(ctx, fetchCommits),
+      this.commits.resolve(ctx, fetchCommits),
+    ]);
+    return Object.freeze<CommitToLint[]>([...titleItems, ...commitItems]);
+  }
+}

--- a/src/strategies/commits.ts
+++ b/src/strategies/commits.ts
@@ -1,0 +1,27 @@
+import type { CommitToLint } from '../types.js';
+import type { LintTargetStrategy, StrategyContext } from './index.js';
+
+/**
+ * Lints every commit returned by the event's fetcher. This is the default
+ * behaviour and preserves backwards compatibility with workflows that do
+ * not specify a `lint-strategy` input.
+ */
+export class CommitsStrategy implements LintTargetStrategy {
+  /**
+   * Invokes the supplied fetcher callback and returns its result
+   * verbatim. Ignores the strategy context entirely; the event-specific
+   * fetcher is the sole source of items.
+   *
+   * @param _ctx Unused; present to satisfy the {@link LintTargetStrategy}
+   * contract.
+   * @param fetchCommits Callback that produces the commits for the
+   * current event (already depth-limited by `run()`).
+   * @returns The commits returned by `fetchCommits`, unchanged.
+   */
+  public async resolve(
+    _ctx: StrategyContext,
+    fetchCommits: () => Promise<ReadonlyArray<CommitToLint>>,
+  ): Promise<ReadonlyArray<CommitToLint>> {
+    return fetchCommits();
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -52,10 +52,15 @@ export interface LintTargetStrategy {
 /**
  * Constructs a {@link LintTargetStrategy} for the given name. The caller
  * is responsible for validating the input value before invoking this
- * factory; all three valid names are handled exhaustively.
+ * factory; all three valid names are handled exhaustively. The default
+ * branch is unreachable under TypeScript's type checker but throws at
+ * runtime as a defensive guard against unchecked casts and future
+ * additions to {@link LintStrategyName} that forget to update this
+ * switch.
  *
  * @param name The parsed `lint-strategy` input value.
  * @returns A ready-to-use strategy instance.
+ * @throws {Error} If `name` is not a recognised strategy at runtime.
  */
 export function getLintStrategy(name: LintStrategyName): LintTargetStrategy {
   switch (name) {
@@ -65,6 +70,10 @@ export function getLintStrategy(name: LintStrategyName): LintTargetStrategy {
       return new PrTitleStrategy();
     case 'both':
       return new BothStrategy();
+    default: {
+      const exhaustive: never = name;
+      throw new Error(`Unknown lint strategy: ${exhaustive as string}`);
+    }
   }
 }
 

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,0 +1,71 @@
+import type { WebhookPayload } from '@actions/github/lib/interfaces.js';
+import type { CommitToLint } from '../types.js';
+import { CommitsStrategy } from './commits.js';
+import { PrTitleStrategy } from './pr-title.js';
+import { BothStrategy } from './both.js';
+
+/**
+ * The set of valid `lint-strategy` input values.
+ */
+export type LintStrategyName = 'commits' | 'pr-title' | 'both';
+
+/**
+ * Read-only context passed to every strategy. The payload is the raw
+ * webhook payload from `@actions/github`; strategies are responsible for
+ * narrowing any specific fields they consume.
+ */
+export interface StrategyContext {
+  readonly eventName: string;
+  readonly payload: Readonly<WebhookPayload>;
+}
+
+/**
+ * Contract for a strategy that decides which items a run of the action
+ * should lint. Strategies are orthogonal to the event-specific commit
+ * fetchers: fetchers produce raw commits for the event, strategies turn
+ * those commits (plus payload-derived items such as the PR title) into
+ * the final list handed to the linter.
+ *
+ * Implementations may choose not to invoke the `fetchCommits` callback,
+ * which avoids a GitHub API round-trip when the strategy has no use for
+ * the fetched commits (e.g. `pr-title`).
+ */
+export interface LintTargetStrategy {
+  /**
+   * Produces the final list of items to lint for the current run.
+   *
+   * @param ctx Read-only context derived from the GitHub workflow run.
+   * @param fetchCommits Lazily-evaluated callback that returns the
+   * commits produced by the event-specific fetcher (already trimmed by
+   * `commit-depth` if set). Implementations may choose not to invoke
+   * the callback to skip the underlying API call.
+   * @returns A frozen, read-only list of items handed to the linter. An
+   * empty list triggers the action's "No commits found to lint" failure
+   * path in `run()`.
+   */
+  resolve(
+    ctx: StrategyContext,
+    fetchCommits: () => Promise<ReadonlyArray<CommitToLint>>,
+  ): Promise<ReadonlyArray<CommitToLint>>;
+}
+
+/**
+ * Constructs a {@link LintTargetStrategy} for the given name. The caller
+ * is responsible for validating the input value before invoking this
+ * factory; all three valid names are handled exhaustively.
+ *
+ * @param name The parsed `lint-strategy` input value.
+ * @returns A ready-to-use strategy instance.
+ */
+export function getLintStrategy(name: LintStrategyName): LintTargetStrategy {
+  switch (name) {
+    case 'commits':
+      return new CommitsStrategy();
+    case 'pr-title':
+      return new PrTitleStrategy();
+    case 'both':
+      return new BothStrategy();
+  }
+}
+
+export { CommitsStrategy, PrTitleStrategy, BothStrategy };

--- a/src/strategies/pr-title.ts
+++ b/src/strategies/pr-title.ts
@@ -1,0 +1,50 @@
+import type { CommitToLint } from '../types.js';
+import type { LintTargetStrategy, StrategyContext } from './index.js';
+
+/**
+ * Lints only the pull request title read from the webhook payload. Does
+ * not invoke the commit fetcher, so no GitHub API call is made on behalf
+ * of this strategy. On events without a `pull_request` payload (push,
+ * merge_group) it returns an empty list; the caller then triggers the
+ * action's standard "No commits found to lint" failure path.
+ *
+ * The synthetic hash is shaped `pr-{number}-title` so it renders
+ * distinctly from a real SHA in the job summary.
+ *
+ * Reads `payload.pull_request` directly from `WebhookPayload`. The
+ * upstream type guarantees `number: number` when `pull_request` is
+ * present, but `title` arrives via the `[key: string]: any` index
+ * signature, so it is captured as `unknown` and runtime-checked before
+ * use to keep `any` from leaking into the rest of the code.
+ */
+export class PrTitleStrategy implements LintTargetStrategy {
+  /**
+   * Builds a single-element list containing the pull request title as a
+   * synthetic {@link CommitToLint}, or an empty list when the payload
+   * has no usable PR title. Never invokes `fetchCommits`, so the
+   * underlying GitHub API call is skipped entirely when this strategy
+   * is selected.
+   *
+   * @param ctx Read-only context whose `payload.pull_request` is
+   * inspected for `title`.
+   * @returns A frozen list with one frozen item on PR events with a
+   * non-empty title, otherwise a frozen empty list.
+   */
+  public async resolve(
+    ctx: StrategyContext,
+  ): Promise<ReadonlyArray<CommitToLint>> {
+    const pr = ctx.payload.pull_request;
+    if (pr === undefined) {
+      return Object.freeze<CommitToLint[]>([]);
+    }
+    const title: unknown = pr.title;
+    if (typeof title !== 'string' || title.length === 0) {
+      return Object.freeze<CommitToLint[]>([]);
+    }
+    const item: Readonly<CommitToLint> = Object.freeze({
+      message: title,
+      hash: `pr-${pr.number}-title`,
+    });
+    return Object.freeze<CommitToLint[]>([item]);
+  }
+}

--- a/src/strategies/pr-title.ts
+++ b/src/strategies/pr-title.ts
@@ -34,7 +34,7 @@ export class PrTitleStrategy implements LintTargetStrategy {
     ctx: StrategyContext,
   ): Promise<ReadonlyArray<CommitToLint>> {
     const pr = ctx.payload.pull_request;
-    if (pr === undefined) {
+    if (pr === undefined || pr === null) {
       return Object.freeze<CommitToLint[]>([]);
     }
     const title: unknown = pr.title;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 // noinspection ES6PreferShortImport
@@ -81,7 +81,7 @@ describe('Commitlint Action Integration Tests', () => {
       event: { name: 'push', payload: {} },
       commits: [{ sha: 'err1', message: 'feat: an invalid type' }],
       expectToThrow: true,
-      expectedErrorMessage: 'Found 1 commit messages with errors',
+      expectedErrorMessage: 'Found 1 commit message with errors',
     },
     {
       description: 'Imperative config, valid commit, should pass',
@@ -151,7 +151,7 @@ describe('Commitlint Action Integration Tests', () => {
       commits: [],
       expectFetcherCalled: false,
       expectToThrow: true,
-      expectedErrorMessage: 'Found 1 commit messages with errors',
+      expectedErrorMessage: 'Found 1 commit message with errors',
     },
     {
       description:
@@ -241,7 +241,7 @@ describe('Commitlint Action Integration Tests', () => {
       commits: [{ sha: 'cmt2', message: 'feat: a valid commit' }],
       expectFetcherCalled: true,
       expectToThrow: true,
-      expectedErrorMessage: 'Found 1 commit messages with errors',
+      expectedErrorMessage: 'Found 1 commit message with errors',
     },
     {
       description:
@@ -317,6 +317,59 @@ describe('Commitlint Action Integration Tests', () => {
       } else {
         await expect(action()).resolves.not.toThrow();
       }
+    })();
+  });
+
+  test('emits a workflow notice when lint-strategy=pr-title skips on a non-PR event', () => {
+    return withTempDir(async ({ tmp }) => {
+      writeFileSync(
+        join(tmp, '.commitlintrc.json'),
+        JSON.stringify({
+          extends: ['@commitlint/config-conventional'],
+          rules: { 'type-enum': [2, 'always', ['feat']] },
+        }),
+      );
+
+      const stdoutChunks: string[] = [];
+      const stdoutSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string | Uint8Array): boolean => {
+          stdoutChunks.push(
+            typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString(),
+          );
+          return true;
+        }) as typeof process.stdout.write);
+
+      try {
+        await runAction(
+          {
+            'github-token': 'fake-token',
+            'working-directory': tmp,
+            'fail-on-errors': 'true',
+            'lint-strategy': 'pr-title',
+          },
+          {
+            GITHUB_WORKSPACE: tmp,
+            GITHUB_EVENT_NAME: 'push',
+            GITHUB_REPOSITORY: 'test-owner/test-repo',
+          },
+          {},
+          (): ICommitFetcher | null => ({
+            fetchCommits: async (): Promise<CommitToLint[]> => {
+              throw new Error(
+                'fetchCommits must not be invoked on the skip path',
+              );
+            },
+          }),
+        );
+      } finally {
+        stdoutSpy.mockRestore();
+      }
+
+      const allOutput = stdoutChunks.join('');
+      expect(allOutput).toContain('::notice::');
+      expect(allOutput).toContain('lint-strategy=pr-title');
+      expect(allOutput).toContain("event 'push'");
     })();
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -185,6 +185,21 @@ describe('Commitlint Action Integration Tests', () => {
     },
     {
       description:
+        'lint-strategy=pr-title with pull_request literally null should skip gracefully',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'pr-title' },
+      event: { name: 'pull_request', payload: { pull_request: null } },
+      commits: [{ sha: 'ignored', message: 'feat: ignored' }],
+      expectFetcherCalled: false,
+      expectToThrow: false,
+    },
+    {
+      description:
         'lint-strategy=both on pull_request with valid title and valid commits, should pass',
       configFileName: '.commitlintrc.json',
       configFileContent: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -108,6 +108,142 @@ describe('Commitlint Action Integration Tests', () => {
       commits: [{ sha: 'impErr2', message: 'fix:' }],
       expectToThrow: false,
     },
+    {
+      description:
+        'lint-strategy=pr-title on pull_request with valid title, should pass and not call fetcher',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'pr-title' },
+      event: {
+        name: 'pull_request',
+        payload: {
+          action: 'opened',
+          number: 42,
+          pull_request: { number: 42, title: 'feat: a valid pr title' },
+        },
+      },
+      commits: [],
+      expectFetcherCalled: false,
+      expectToThrow: false,
+    },
+    {
+      description:
+        'lint-strategy=pr-title on pull_request with invalid title, should fail',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['fix']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'pr-title' },
+      event: {
+        name: 'pull_request',
+        payload: {
+          action: 'opened',
+          number: 7,
+          pull_request: { number: 7, title: 'feat: wrong type' },
+        },
+      },
+      commits: [],
+      expectFetcherCalled: false,
+      expectToThrow: true,
+      expectedErrorMessage: 'Found 1 commit messages with errors',
+    },
+    {
+      description:
+        'lint-strategy=pr-title on push event should skip gracefully without throwing',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'pr-title' },
+      event: { name: 'push', payload: {} },
+      commits: [{ sha: 'ignored', message: 'feat: ignored' }],
+      expectFetcherCalled: false,
+      expectToThrow: false,
+    },
+    {
+      description:
+        'lint-strategy=pr-title on merge_group event should skip gracefully without throwing',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'pr-title' },
+      event: { name: 'merge_group', payload: {} },
+      commits: [{ sha: 'ignored', message: 'feat: ignored' }],
+      expectFetcherCalled: false,
+      expectToThrow: false,
+    },
+    {
+      description:
+        'lint-strategy=both on pull_request with valid title and valid commits, should pass',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'both' },
+      event: {
+        name: 'pull_request',
+        payload: {
+          action: 'opened',
+          number: 11,
+          pull_request: { number: 11, title: 'feat: a valid title' },
+        },
+      },
+      commits: [{ sha: 'cmt1', message: 'feat: a valid commit' }],
+      expectFetcherCalled: true,
+      expectToThrow: false,
+    },
+    {
+      description:
+        'lint-strategy=both on pull_request with invalid title but valid commits, should fail on title',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'both' },
+      event: {
+        name: 'pull_request',
+        payload: {
+          action: 'opened',
+          number: 12,
+          pull_request: { number: 12, title: 'bad: wrong type' },
+        },
+      },
+      commits: [{ sha: 'cmt2', message: 'feat: a valid commit' }],
+      expectFetcherCalled: true,
+      expectToThrow: true,
+      expectedErrorMessage: 'Found 1 commit messages with errors',
+    },
+    {
+      description:
+        'lint-strategy=garbage should throw an input validation error',
+      configFileName: '.commitlintrc.json',
+      configFileContent: {
+        extends: ['@commitlint/config-conventional'],
+        rules: { 'type-enum': [2, 'always', ['feat']] },
+      },
+      createPkgJson: false,
+      inputs: { 'fail-on-errors': 'true', 'lint-strategy': 'nonsense' },
+      event: { name: 'push', payload: {} },
+      commits: [{ sha: 'valid1', message: 'feat: a valid commit' }],
+      expectFetcherCalled: false,
+      expectToThrow: true,
+      expectedErrorMessage: 'Invalid value for "lint-strategy"',
+    },
   ];
 
   test.each(testMatrix)('$description', (params) => {
@@ -142,6 +278,14 @@ describe('Commitlint Action Integration Tests', () => {
           (): ICommitFetcher | null => {
             return {
               fetchCommits: async (): Promise<CommitToLint[]> => {
+                if (
+                  'expectFetcherCalled' in params &&
+                  params.expectFetcherCalled === false
+                ) {
+                  throw new Error(
+                    'fetchCommits was called but the test asserted it must not be',
+                  );
+                }
                 const transformedCommits = params.commits.map((commit) => ({
                   hash: commit.sha,
                   message: commit.message,

--- a/test/linter/result.test.ts
+++ b/test/linter/result.test.ts
@@ -54,6 +54,54 @@ describe('Results', () => {
     warnings: [],
   };
 
+  const multiErrorCommit = {
+    hash: 'r3s4t5u',
+    input: 'something broken',
+    valid: false,
+    errors: [
+      {
+        level: 2,
+        valid: false,
+        name: 'type-empty',
+        message: 'Type may not be empty',
+      },
+      {
+        level: 2,
+        valid: false,
+        name: 'subject-case',
+        message: 'Subject must be in lowercase',
+      },
+      {
+        level: 2,
+        valid: false,
+        name: 'header-max-length',
+        message: 'Header is too long',
+      },
+    ],
+    warnings: [],
+  };
+
+  const multiWarningCommit = {
+    hash: 'v6w7x8y',
+    input: 'docs: too many warnings here',
+    valid: true,
+    errors: [],
+    warnings: [
+      {
+        level: 1,
+        valid: true,
+        name: 'subject-max-length',
+        message: 'Subject too long',
+      },
+      {
+        level: 1,
+        valid: true,
+        name: 'body-leading-blank',
+        message: 'Body should start with blank line',
+      },
+    ],
+  };
+
   test('should correctly calculate counts and states for mixed results', () => {
     const items = [cleanCommit, warningCommit, errorCommit1, errorCommit2];
     const results = new Results(items, 'https://example.com/rules');
@@ -63,6 +111,8 @@ describe('Results', () => {
     expect(results.checkedCount).toBe(4);
     expect(results.errorCount).toBe(2);
     expect(results.warningCount).toBe(1);
+    expect(results.errorCommitsCount).toBe(2);
+    expect(results.warningCommitsCount).toBe(1);
     expect(results.hasErrors).toBe(true);
     expect(results.hasOnlyWarnings).toBe(false);
   });
@@ -74,6 +124,8 @@ describe('Results', () => {
     expect(results.checkedCount).toBe(2);
     expect(results.errorCount).toBe(0);
     expect(results.warningCount).toBe(1);
+    expect(results.errorCommitsCount).toBe(0);
+    expect(results.warningCommitsCount).toBe(1);
     expect(results.hasErrors).toBe(false);
     expect(results.hasOnlyWarnings).toBe(true);
   });
@@ -85,6 +137,8 @@ describe('Results', () => {
     expect(results.checkedCount).toBe(2);
     expect(results.errorCount).toBe(1);
     expect(results.warningCount).toBe(0);
+    expect(results.errorCommitsCount).toBe(1);
+    expect(results.warningCommitsCount).toBe(0);
     expect(results.hasErrors).toBe(true);
     expect(results.hasOnlyWarnings).toBe(false);
   });
@@ -96,6 +150,8 @@ describe('Results', () => {
     expect(results.checkedCount).toBe(2);
     expect(results.errorCount).toBe(0);
     expect(results.warningCount).toBe(0);
+    expect(results.errorCommitsCount).toBe(0);
+    expect(results.warningCommitsCount).toBe(0);
     expect(results.hasErrors).toBe(false);
     expect(results.hasOnlyWarnings).toBe(false);
   });
@@ -107,7 +163,25 @@ describe('Results', () => {
     expect(results.checkedCount).toBe(0);
     expect(results.errorCount).toBe(0);
     expect(results.warningCount).toBe(0);
+    expect(results.errorCommitsCount).toBe(0);
+    expect(results.warningCommitsCount).toBe(0);
     expect(results.hasErrors).toBe(false);
     expect(results.hasOnlyWarnings).toBe(false);
+  });
+
+  test('errorCommitsCount counts commits, not errors, when one commit has many errors', () => {
+    const items = [cleanCommit, multiErrorCommit];
+    const results = new Results(items, 'https://example.com/rules');
+
+    expect(results.errorCount).toBe(3);
+    expect(results.errorCommitsCount).toBe(1);
+  });
+
+  test('warningCommitsCount counts commits, not warnings, when one commit has many warnings', () => {
+    const items = [cleanCommit, multiWarningCommit];
+    const results = new Results(items, 'https://example.com/rules');
+
+    expect(results.warningCount).toBe(2);
+    expect(results.warningCommitsCount).toBe(1);
   });
 });

--- a/test/strategies/both.test.ts
+++ b/test/strategies/both.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { BothStrategy } from '../../src/strategies/both.js';
+import { CommitsStrategy } from '../../src/strategies/commits.js';
+import { PrTitleStrategy } from '../../src/strategies/pr-title.js';
+import type { CommitToLint } from '../../src/types.js';
+import type {
+  LintTargetStrategy,
+  StrategyContext,
+} from '../../src/strategies/index.js';
+
+describe('BothStrategy', () => {
+  const strategy = new BothStrategy();
+
+  test('returns [title, ...commits] when both are present', async () => {
+    const commits: ReadonlyArray<CommitToLint> = [
+      { hash: 'a1', message: 'feat: one' },
+      { hash: 'b2', message: 'fix: two' },
+    ];
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue(commits);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 42, title: 'feat: title' } },
+    };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([
+      { hash: 'pr-42-title', message: 'feat: title' },
+      { hash: 'a1', message: 'feat: one' },
+      { hash: 'b2', message: 'fix: two' },
+    ]);
+    expect(fetchCommits).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns just the commits when PR title is absent (push event)', async () => {
+    const commits: ReadonlyArray<CommitToLint> = [
+      { hash: 'c3', message: 'chore: only commits' },
+    ];
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue(commits);
+
+    const ctx: StrategyContext = { eventName: 'push', payload: {} };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual(commits);
+    expect(fetchCommits).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns just the title when commits are empty', async () => {
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue([]);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 7, title: 'feat: lone title' } },
+    };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([
+      { hash: 'pr-7-title', message: 'feat: lone title' },
+    ]);
+  });
+
+  test('does not count the PR title towards commit-depth', async () => {
+    const commits: ReadonlyArray<CommitToLint> = [
+      { hash: 'a1', message: 'feat: one' },
+      { hash: 'b2', message: 'fix: two' },
+      { hash: 'c3', message: 'chore: three' },
+    ];
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue(commits);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 1, title: 'feat: root' } },
+    };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({
+      hash: 'pr-1-title',
+      message: 'feat: root',
+    });
+  });
+
+  test('returned array is frozen', async () => {
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue([{ hash: 'a1', message: 'feat: one' }]);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 1, title: 'feat: x' } },
+    };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  test('delegates to injected sub-strategies via constructor', async () => {
+    const prTitleResolve = jest.fn<LintTargetStrategy['resolve']>();
+    prTitleResolve.mockResolvedValue([
+      { hash: 'title-hash', message: 'from mock title' },
+    ]);
+    const commitsResolve = jest.fn<LintTargetStrategy['resolve']>();
+    commitsResolve.mockResolvedValue([
+      { hash: 'commit-hash', message: 'from mock commits' },
+    ]);
+
+    const prTitleMock: PrTitleStrategy = Object.assign(new PrTitleStrategy(), {
+      resolve: prTitleResolve,
+    });
+    const commitsMock: CommitsStrategy = Object.assign(new CommitsStrategy(), {
+      resolve: commitsResolve,
+    });
+
+    const composed = new BothStrategy(commitsMock, prTitleMock);
+
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue([]);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 1, title: 'feat: ignored' } },
+    };
+    const result = await composed.resolve(ctx, fetchCommits);
+
+    expect(prTitleResolve).toHaveBeenCalledTimes(1);
+    expect(commitsResolve).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { hash: 'title-hash', message: 'from mock title' },
+      { hash: 'commit-hash', message: 'from mock commits' },
+    ]);
+  });
+});

--- a/test/strategies/commits.test.ts
+++ b/test/strategies/commits.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { CommitsStrategy } from '../../src/strategies/commits.js';
+import type { CommitToLint } from '../../src/types.js';
+import type { StrategyContext } from '../../src/strategies/index.js';
+
+describe('CommitsStrategy', () => {
+  const strategy = new CommitsStrategy();
+
+  test('delegates to fetchCommits and returns its result verbatim', async () => {
+    const commits: ReadonlyArray<CommitToLint> = [
+      { hash: 'a1', message: 'feat: one' },
+      { hash: 'b2', message: 'fix: two' },
+    ];
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue(commits);
+
+    const ctx: StrategyContext = { eventName: 'push', payload: {} };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual(commits);
+    expect(fetchCommits).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores payload.pull_request even when present', async () => {
+    const commits: ReadonlyArray<CommitToLint> = [
+      { hash: 'c3', message: 'chore: three' },
+    ];
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue(commits);
+
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: {
+        pull_request: { number: 7, title: 'feat: from title' },
+      },
+    };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual(commits);
+    expect(result).not.toContainEqual({
+      hash: 'pr-7-title',
+      message: 'feat: from title',
+    });
+  });
+
+  test('returns an empty list when fetcher returns empty', async () => {
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockResolvedValue([]);
+
+    const ctx: StrategyContext = { eventName: 'push', payload: {} };
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([]);
+    expect(fetchCommits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/strategies/index.test.ts
+++ b/test/strategies/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  BothStrategy,
+  CommitsStrategy,
+  PrTitleStrategy,
+  getLintStrategy,
+  type LintStrategyName,
+} from '../../src/strategies/index.js';
+
+describe('getLintStrategy factory', () => {
+  const cases: ReadonlyArray<{
+    name: LintStrategyName;
+    expected: new () => object;
+  }> = [
+    { name: 'commits', expected: CommitsStrategy },
+    { name: 'pr-title', expected: PrTitleStrategy },
+    { name: 'both', expected: BothStrategy },
+  ];
+
+  test.each(cases)(
+    'returns an instance of $expected.name for "$name"',
+    ({ name, expected }) => {
+      const strategy = getLintStrategy(name);
+      expect(strategy).toBeInstanceOf(expected);
+    },
+  );
+});

--- a/test/strategies/index.test.ts
+++ b/test/strategies/index.test.ts
@@ -24,4 +24,10 @@ describe('getLintStrategy factory', () => {
       expect(strategy).toBeInstanceOf(expected);
     },
   );
+
+  test('throws on an unrecognised strategy name (defensive default branch)', () => {
+    expect(() =>
+      getLintStrategy('totally-bogus' as unknown as LintStrategyName),
+    ).toThrow('Unknown lint strategy: totally-bogus');
+  });
 });

--- a/test/strategies/pr-title.test.ts
+++ b/test/strategies/pr-title.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { PrTitleStrategy } from '../../src/strategies/pr-title.js';
+import type { CommitToLint } from '../../src/types.js';
+import type { StrategyContext } from '../../src/strategies/index.js';
+
+describe('PrTitleStrategy', () => {
+  const strategy = new PrTitleStrategy();
+
+  const makeFetcher = () => {
+    const fetchCommits = jest.fn<() => Promise<ReadonlyArray<CommitToLint>>>();
+    fetchCommits.mockImplementation(() => {
+      throw new Error(
+        'PrTitleStrategy must not invoke fetchCommits (no API call allowed)',
+      );
+    });
+    return fetchCommits;
+  };
+
+  test('returns a single frozen item with the PR title', async () => {
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 42, title: 'feat: hello world' } },
+    };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([
+      { hash: 'pr-42-title', message: 'feat: hello world' },
+    ]);
+    expect(fetchCommits).toHaveBeenCalledTimes(0);
+  });
+
+  test('never calls fetchCommits', async () => {
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 1, title: 'fix: bug' } },
+    };
+    const fetchCommits = makeFetcher();
+
+    await strategy.resolve(ctx, fetchCommits);
+
+    expect(fetchCommits).not.toHaveBeenCalled();
+  });
+
+  test('returns an empty list when payload.pull_request is missing', async () => {
+    const ctx: StrategyContext = { eventName: 'push', payload: {} };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([]);
+    expect(fetchCommits).not.toHaveBeenCalled();
+  });
+
+  test('returns an empty list when PR title is an empty string', async () => {
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 5, title: '' } },
+    };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([]);
+  });
+
+  test('returns an empty list when PR title is not a string', async () => {
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 5 } },
+    };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([]);
+  });
+
+  test('returned array and items are frozen', async () => {
+    const ctx: StrategyContext = {
+      eventName: 'pull_request',
+      payload: { pull_request: { number: 99, title: 'feat: immutable' } },
+    };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result[0])).toBe(true);
+  });
+
+  test('empty-path result is also frozen', async () => {
+    const ctx: StrategyContext = { eventName: 'push', payload: {} };
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+});

--- a/test/strategies/pr-title.test.ts
+++ b/test/strategies/pr-title.test.ts
@@ -53,6 +53,19 @@ describe('PrTitleStrategy', () => {
     expect(fetchCommits).not.toHaveBeenCalled();
   });
 
+  test('returns an empty list when payload.pull_request is literally null', async () => {
+    const ctx = {
+      eventName: 'pull_request',
+      payload: { pull_request: null },
+    } as unknown as StrategyContext;
+    const fetchCommits = makeFetcher();
+
+    const result = await strategy.resolve(ctx, fetchCommits);
+
+    expect(result).toEqual([]);
+    expect(fetchCommits).not.toHaveBeenCalled();
+  });
+
   test('returns an empty list when PR title is an empty string', async () => {
     const ctx: StrategyContext = {
       eventName: 'pull_request',


### PR DESCRIPTION
## Description

Adds a new `lint-strategy` action input with three values:

- **`commits`** (default) — lints every commit in the event. Identical to today's behaviour.
- **`pr-title`** — lints only the pull request title, read straight from the webhook payload (no extra GitHub API call).
- **`both`** — lints the PR title and every commit.

Implemented as a Strategy pattern in `src/strategies/` (`CommitsStrategy`, `PrTitleStrategy`, `BothStrategy` + a tiny `getLintStrategy()` factory). Strategies sit between the existing event-specific commit fetchers and the linter, so the fetcher layer is unchanged.

When `lint-strategy: pr-title` is used on an event without a pull request in the payload (`push`, `merge_group`, etc.), the action emits a `core.notice()` and exits successfully instead of failing with "No commits found to lint". This makes the strategy safe to combine with `push: branches: [main]` triggers — the post-merge `push` run no longer fails.

`commit-depth` continues to limit commits only; the PR title is never trimmed.

This PR also includes several drive-by quality fixes discovered during multi-round review:
- Restored proper noun/verb agreement in the `DefaultFormatter` Job Summary lines
- Pluralized the "All N commit messages are okay" success log
- Fixed a "warning" → "warnings" typo in the `fail-on-warnings` notice

## Related Issue

N/A — direct contribution.

## Motivation and Context

For repositories that use **squash-merge**, individual commits on a feature branch are discarded at merge time. The single squash commit that lands in `main` defaults its message to the **PR title**, so linting the per-commit messages is busywork — the thing that actually ends up in git history is the PR title, and that is what should be enforced.

Before this change, users had no way to point this action at the PR title. After this change, `lint-strategy: pr-title` does exactly that, with zero extra API calls (the title is read from the existing webhook payload).

The graceful skip on non-PR events was added after a footgun was identified: a workflow with both `pull_request` and `push: branches: [main]` triggers would fail every merge under `pr-title` because the post-merge `push` event has no PR title in its payload. The skip-with-notice behaviour makes the mixed-trigger pattern safe.

## How Has This Been Tested?

- Unit tests for all three strategy classes in `test/strategies/{commits,pr-title,both,index}.test.ts`, including:
  - Frozen-array assertions on every code path
  - `PrTitleStrategy` asserting the fetcher is **never** invoked (mock throws on call)
  - `BothStrategy` constructor injection + depth interaction (PR title not counted toward `commit-depth`)
  - Factory test covering all three strategy names
- Integration tests added to `test/index.test.ts` covering:
  - `pr-title` on `pull_request` with valid/invalid title
  - `pr-title` on `push` and `merge_group` (asserts graceful skip, fetcher not called)
  - `both` on `pull_request` with valid title + commits, and invalid title + valid commits
  - Garbage `lint-strategy` value rejected with a clear error
- Verification suite (all green): `prettier --check`, `npm run lint`, `tsc --noEmit`, `knip`, `npm test`, `npm run build`
- **100% line/branch/function coverage** on `src/strategies/*`
- **81 tests pass across 14 suites**

## Documentation:

README updated:
- New `lint-strategy` entry in the **Inputs** section documenting all three values
- New **Squash-merge workflows** subsection with a copy-paste recipe and explanation of why
- The graceful-skip behaviour is called out as a "Safe with mixed triggers" note

JSDoc on every new class, interface, method, and the input parser.

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
