### PR TITLE
fix: pin auto-installed @commitlint/* configs to engine major

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -257695,6 +257695,27 @@ class Linter {
 
 /* eslint-disable testing-library/no-debugging-utils */
 /**
+ * Major version of the commitlint engine this action bundles (see the
+ * `@commitlint/*` entries in package.json). Keep in sync when bumping them.
+ */
+const COMMITLINT_ENGINE_RANGE = '^19';
+/**
+ * Default version range for a detected config/plugin that was declared
+ * without an explicit one (e.g. `extends: ["@commitlint/config-conventional"]`).
+ *
+ * Most packages default to `*` (latest). The exception is the `@commitlint/*`
+ * scope: those configs ship a `parserPreset` consumed by the bundled
+ * commitlint engine, so installing a newer major than the engine breaks
+ * config loading. Concretely, `@commitlint/config-conventional@20` is ESM-only
+ * and its parser preset is not loaded by the v19 engine, which makes the
+ * conventional breaking-change `!` (e.g. `feat!: ...`) parse as an empty
+ * header and fail with "type/subject may not be empty". Pin the scope to the
+ * engine's major so the resolved config always matches. See issue #37.
+ */
+function defaultVersionFor(name) {
+    return name.startsWith('@commitlint/') ? COMMITLINT_ENGINE_RANGE : '*';
+}
+/**
  * Creates a loader that extracts plugin dependencies from declarative configs
  * and generates a package.json file with versions if specified.
  *
@@ -257744,7 +257765,7 @@ function declarativeLoader(loader) {
                         acc[name] = entry.slice(at + 1);
                     }
                     else {
-                        acc[name] = '*';
+                        acc[name] = defaultVersionFor(name);
                     }
                 }
                 return acc;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -7,6 +7,29 @@ import type { Loader } from 'cosmiconfig';
 import { defaultLoaders } from 'cosmiconfig';
 
 /**
+ * Major version of the commitlint engine this action bundles (see the
+ * `@commitlint/*` entries in package.json). Keep in sync when bumping them.
+ */
+const COMMITLINT_ENGINE_RANGE = '^19';
+
+/**
+ * Default version range for a detected config/plugin that was declared
+ * without an explicit one (e.g. `extends: ["@commitlint/config-conventional"]`).
+ *
+ * Most packages default to `*` (latest). The exception is the `@commitlint/*`
+ * scope: those configs ship a `parserPreset` consumed by the bundled
+ * commitlint engine, so installing a newer major than the engine breaks
+ * config loading. Concretely, `@commitlint/config-conventional@20` is ESM-only
+ * and its parser preset is not loaded by the v19 engine, which makes the
+ * conventional breaking-change `!` (e.g. `feat!: ...`) parse as an empty
+ * header and fail with "type/subject may not be empty". Pin the scope to the
+ * engine's major so the resolved config always matches. See issue #37.
+ */
+function defaultVersionFor(name: string): string {
+  return name.startsWith('@commitlint/') ? COMMITLINT_ENGINE_RANGE : '*';
+}
+
+/**
  * Creates a loader that extracts plugin dependencies from declarative configs
  * and generates a package.json file with versions if specified.
  *
@@ -57,7 +80,7 @@ function declarativeLoader(loader: Loader): Loader {
             if (at > 0 && entry.startsWith('@')) {
               acc[name] = entry.slice(at + 1);
             } else {
-              acc[name] = '*';
+              acc[name] = defaultVersionFor(name);
             }
           }
 

--- a/test/loaders.test.ts
+++ b/test/loaders.test.ts
@@ -77,3 +77,26 @@ it.each([
       );
     })(),
 );
+
+it('pins an unversioned @commitlint/* config to the bundled engine major', () =>
+  withTempDir(async ({ tmp }) => {
+    const filepath = join(tmp, '.commitlintrc.json');
+    writeFileSync(
+      filepath,
+      JSON.stringify({ extends: ['@commitlint/config-conventional'] }, null, 2),
+    );
+
+    const explorer = cosmiconfig('commitlint', {
+      stopDir: tmp,
+      loaders: createLoaders(),
+    });
+
+    const result = await explorer.search(tmp);
+    expect(result?.filepath).toBe(filepath);
+
+    const pkgJson = JSON.parse(readFileSync(join(tmp, 'package.json'), 'utf8'));
+    const deps = pkgJson.dependencies || pkgJson.devDependencies;
+    // Must NOT be '*' (which resolves to config-conventional@20, ESM-only and
+    // incompatible with the bundled v19 engine — breaks `feat!:` parsing, #37).
+    expect(deps['@commitlint/config-conventional']).toBe('^19');
+  })());


### PR DESCRIPTION
## Description

A declarative commitlint config that `extends` a `@commitlint/*` preset without pinning a version (e.g. `extends: ["@commitlint/config-conventional"]`) was written into the generated `package.json` as `*`, so npm installed the latest major. The action bundles the commitlint engine (`@commitlint/lint`/`load`) at `^19`, and `@commitlint/config-conventional@20` is ESM-only with a `parserPreset` the v19 engine does not load. The conventional parser then falls back to the default parser, which does not understand the breaking-change `!`, so a perfectly valid `feat!: …` commit parses as an empty header and fails with `type may not be empty` / `subject may not be empty`.

This pins detected `@commitlint/*` configs to the bundled engine's major (`^19`) when no explicit version is given; every other package still defaults to `*`.

## Related Issue

Closes #37

## Motivation and Context

The action's code did not change — `@commitlint/config-conventional` published a v20 major and the action installed `@latest`, so the runtime drifted under stable code. Any repository using a `feat!:`/`fix!:` breaking-change commit started failing the lint with a misleading "empty type/subject" error. Pinning the install to the engine major restores correct parsing and keeps the resolved config ABI-compatible with the bundled engine.

## How Has This Been Tested?

- Added a unit test asserting an unversioned `@commitlint/config-conventional` is written as `^19` (not `*`).
- `npm test` (84 tests) passes; `npm run build`, `npm run lint`, and `npm run format:check` are clean.
- Reproduced the original failure with the prior `dist` against a live `feat!:` PR and confirmed the rebuilt `dist` resolves config-conventional `^19` and parses the breaking-change header correctly.

## Documentation:

N/A — internal dependency-resolution fix; no user-facing API or input changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
